### PR TITLE
add more information to DE specific structures

### DIFF
--- a/mgz/body/__init__.py
+++ b/mgz/body/__init__.py
@@ -65,8 +65,9 @@ action_data = "action"/Struct(
         "sell": actions.sell,
         "buy": actions.buy,
         "backtowork": actions.backtowork,
-        "de": actions.de,
-        "postgame": actions.postgame
+        "de_queue": actions.de_queue,
+        "postgame": actions.postgame,
+        "de_attackmove": actions.de_attackmove
     }, default=Struct(
         "unk_action"/Computed(lambda ctx: ctx._.type),
         "bytes"/Bytes(lambda ctx: ctx._._.length - 1)

--- a/mgz/body/actions.py
+++ b/mgz/body/actions.py
@@ -258,7 +258,25 @@ game = "game"/Struct(
         "amount"/Byte,
         Padding(7)
     )),
-    "de"/If(this.mode == 'de', Bytes(lambda ctx: ctx._._.length - 7)),
+
+    # toggle farm auto seed queue
+    "farm_autoqueue"/If(this.mode == 'farm_autoqueue', Struct(
+        Padding(9)
+    )),
+
+    "fishtrap_queue" / If(this.mode == 'fishtrap_queue', Struct(
+        "amount" / Byte,
+        Padding(8)
+    )),
+    "fishtrap_unqueue" / If(this.mode == 'fishtrap_unqueue', Struct(
+        "amount" / Byte,
+        Padding(8)
+    )),
+
+    # toggle fish trap auto seed queue
+    "fishtrap_autoqueue"/If(this.mode == 'fishtrap_autoqueue', Struct(
+        Padding(9)
+    )),
     Padding(3)
 )
 
@@ -434,16 +452,36 @@ ai_command = "ai_command"/Struct(
     Padding(lambda ctx: ctx._._.length - 1)
 )
 
-de = "de"/Struct(
+"""DE Queue
+
+In DE queue and multi queue share the same command
+"""
+de_queue = "de_queue"/Struct(
     "player_id"/Byte,
-    "unknown0"/Padding(2),
+    "building_type"/Int16ul,
     "selected"/Byte,
-    "unknown1"/Padding(5),
-    Array(lambda ctx: ctx.selected, "unit_ids"/Int32ul)
+    Padding(1),
+    "unit_type"/Int16ul,
+    "queue_amount"/Byte,
+    Padding(1),
+    Array(lambda ctx: ctx.selected, "building_ids"/Int32ul)
 )
 
-de2 = "de2"/Struct(
-    "unknown"/Bytes(lambda ctx: ctx._._.length - 1)
+"""DE Attack Move
+
+It's almost the same as Patrol.
+
+10 X-coordinates followed by 10 Y-coordinates
+First of each is popped off for consistency with other actions
+"""
+de_attackmove = "de_attackmove"/Struct(
+    "selected"/Byte,
+    "waypoints"/Int16ul,
+    "x"/Float32l,
+    Array(9, "x_more"/Float32l),
+    "y"/Float32l,
+    Array(9, "y_more"/Float32l),
+    Array(lambda ctx: ctx.selected, "unit_ids"/Int32ul),
 )
 
 postgame = "achievements"/Struct(

--- a/mgz/enums.py
+++ b/mgz/enums.py
@@ -265,7 +265,10 @@ def GameActionModeEnum(ctx):
         unk1=11,
         farm_queue=13,
         farm_unqueue=14,
-        de=16,
+        farm_autoqueue=16,
+        fishtrap_queue=17,
+        fishtrap_unqueue=18,
+        fishtrap_autoqueue=19,
         default=Pass
     )
 
@@ -345,7 +348,7 @@ def ActionEnum(ctx):
         save=27,
         ai_waypoint=31,
         chapter=32,
-        de2=33,
+        de_attackmove=33,
         ai_command=53,
         ai_queue=100,
         research=101,
@@ -368,7 +371,7 @@ def ActionEnum(ctx):
         droprelic=126,
         townbell=127,
         backtowork=128,
-        de=129,
+        de_queue=129,
         postgame=255,
         default=Pass
     )

--- a/mgz/fast.py
+++ b/mgz/fast.py
@@ -34,7 +34,7 @@ class Action(Enum):
     SAVE = 27
     GROUP_MULTI_WAYPOINTS = 31
     CHAPTER = 32
-    DE2 = 33
+    DE_ATTACK_MOVE = 33
     AI_COMMAND = 53
     MAKE = 100
     RESEARCH = 101
@@ -57,7 +57,7 @@ class Action(Enum):
     DROP_RELIC = 126
     TOWN_BELL = 127
     BACK_TO_WORK = 128
-    DE = 129
+    DE_QUEUE = 129
     POSTGAME = 255
 
 


### PR DESCRIPTION
this updates:
`de` to `de_queue` - which combines queue and multiqueue from UP1.5, 
`de2` to `de_attackmove` - which has the same attributes as `patrol`
in `game` it changes 
`de` mode to `farm_autoqueue` - for when the farm_autoqueue button is toggled (you could opt to add toggle to the name for clarity), it has no arguments
adds `fishtrap_autoqueue` - no arguments
adds `fishtrap_queue` and `fishtrap_unqueue` similar to the farm versions but without a player_id field

Of course feel free to comment on my Python style and other coding conventions and ask me to make updates.