### PR TITLE
pad actions to actual size in "full" parser

### DIFF
--- a/mgz/body/__init__.py
+++ b/mgz/body/__init__.py
@@ -12,7 +12,7 @@ An Operation can be:
 
 from construct import (Struct, Byte, Switch, Embedded, Padding,
                        Int32ul, Peek, Tell, Float32l, String, If, Array, Bytes,
-                       GreedyBytes, Computed, IfThenElse, Int16ul, Int64ul, Seek)
+                       GreedyBytes, Computed, IfThenElse, Int16ul, Int64ul, Seek, Padded)
 from mgz.enums import ActionEnum, OperationEnum
 from mgz.body import actions, embedded
 from mgz.util import BoolAdapter
@@ -82,7 +82,7 @@ action_data = "action"/Struct(
 # Action - length followed by data.
 action = "action"/Struct(
     "length"/Int32ul,
-    action_data
+    Padded(lambda ctx: ctx.length + 4, action_data)
 )
 
 


### PR DESCRIPTION
This pull requests solves #24 by simply ensuring that as much bytes are getting read as "length" defines.
It simply adds a padding if not all bytes were consumed (and thus ignores all exceeding bytes!).

This behaviour is more or less equal to the fast parser:
```
    length, = struct.unpack('<I', data.read(4))
    action_id = int.from_bytes(data.read(1), 'little')
    action_bytes = data.read(length - 1)
    data.read(4)
```

I've tested it with DE records and it allows me to parse as many operations as the fast-parser does.