### PR TITLE
Skip ai settings in DE as long as we didn't know the correct structure

### DIFF
--- a/mgz/header/ai.py
+++ b/mgz/header/ai.py
@@ -1,10 +1,11 @@
 """AI."""
 
+from mgz import Version
+from mgz.util import Find
 from construct import (Array, Byte, If, Int16ul, Int32sl, Int32ul, Padding,
-                       PascalString, Struct, this)
+                       PascalString, Struct, this, IfThenElse)
 
 # pylint: disable=invalid-name
-
 
 script = "script"/Struct(
     Padding(4),
@@ -28,17 +29,21 @@ script = "script"/Struct(
 
 ai = "ai"/Struct(
     "has_ai"/Int32ul, # if true, parse AI
-    "yep"/If(this.has_ai == 1, "ais"/Struct(
-        "max_strings"/Int16ul,
-        "num_strings"/Int16ul,
-        Padding(4),
-        Array(this.num_strings, "strings"/PascalString(lengthfield="name_length"/Int32ul,
-                                                       encoding='latin1')),
-        Padding(6),
-        Array(8, script),
-        Padding(104),
-        Array(80, "timers"/Int32sl),
-        Array(256, "shared_goals"/Int32sl),
-        Padding(4096),
-    ))
+    "yep"/IfThenElse(
+        lambda ctx: ctx._.version == Version.DE,
+        Find(b'\00' * 4096, None),  # The ai structure in DE seems to have changed, for now we simply skip it
+        If(this.has_ai == 1, "ais"/Struct(
+            "max_strings"/Int16ul,
+            "num_strings"/Int16ul,
+            Padding(4),
+            Array(this.num_strings, "strings"/PascalString(lengthfield="name_length"/Int32ul,
+                                                           encoding='latin1')),
+            Padding(6),
+            Array(8, script),
+            Padding(104),
+            Array(80, "timers"/Int32sl),
+            Array(256, "shared_goals"/Int32sl),
+            Padding(4096),
+        ))
+    )
 )


### PR DESCRIPTION
This pull requests solves the issue of reading recorded games which involves ai players for AoE2 DE recs.
It works by simply skipping the ai settings in DE recorded games, since i wasn't able to figure out the format changes, so this will still be an open task.

So be aware: With this PR you can check if an ai is included ('has_ai' == 1) but you will not see any settings ('yep'/'yep->ais' is empty).