### PR TITLE
Added location of production queue cancellation

### DIFF
--- a/mgz/body/actions.py
+++ b/mgz/body/actions.py
@@ -393,7 +393,8 @@ order = "order"/Struct(
     Padding(2),
     "building_id"/Int32sl, # -1 cancels production queue
     OrderTypeEnum("order_type"/Byte),
-    Padding(3),
+    "queue_location"/Byte, # Location of cancellation in the production queue 0 being the unit currently being built
+    Padding(2),
     "x"/Float32l,
     "y"/Float32l,
     Padding(4), # const

--- a/mgz/enums.py
+++ b/mgz/enums.py
@@ -276,6 +276,7 @@ def OrderTypeEnum(ctx):
         ctx,
         packtreb=1,
         unpacktreb=2,
+        cancel_unit=4,
         garrison=5,
         default=Pass
     )


### PR DESCRIPTION
Seems to all work in my testing, though am slightly suspicious that the order type wasn't specified but building_id=-1 has a comment for it.