### PR TITLE
fixed "unknown" byte placement in "wall" action

### DIFF
--- a/mgz/body/actions.py
+++ b/mgz/body/actions.py
@@ -308,19 +308,23 @@ droprelic = "droprelic"/Struct(
 wall = "wall"/Struct(
     "selected"/Byte,
     "player_id"/Byte,
-    "start_x"/Byte,
-    "start_y"/Byte,
-    "end_x"/Byte,
-    "end_y"/Byte,
-    Padding(1),
     IfThenElse(lambda ctx: ctx._._.length - 16 - (ctx.selected * 4) == 8,
         Embedded(Struct(
-            "unk"/Bytes(4),
+            Padding(1),
+            "start_x"/Int16ul,
+            "start_y"/Int16ul,
+            "end_x"/Int16ul,
+            "end_y"/Int16ul,
             "building_id"/Int32ul,
             Padding(4),
             "flags"/Bytes(4)
         )),
         Embedded(Struct(
+            "start_x"/Byte,
+            "start_y"/Byte,
+            "end_x"/Byte,
+            "end_y"/Byte,
+            Padding(1),
             "building_id"/Int32ul,
             Padding(4),
         ))


### PR DESCRIPTION
I rearranged the unknown bytes in the "wall" action, it looks like those are individual zero bytes right before each of start_{x,y} and end_{x,y}. So in the current implementation `start_x` and `end_x` are always 0, while the "unk" field holds the actual values:

```
import os
from mgz import header, body


with open("var/savegames/MP Replay v101.101.43210.0 @2020.12.21 141238 (3).aoe2record", "rb") as data:
    eof = os.fstat(data.fileno()).st_size
    header.parse_stream(data)
    body.meta.parse_stream(data)
    while data.tell() < eof:
        op = body.operation.parse_stream(data)
        
        if op.type == "action" and op.action.type == "wall":
            print(op)
            break
```

Result:
```
Container: 
    type = action (total 6)
    start = 1110834
    op = 1
    length = 28
    action = Container: 
        type_int = 105
        type = wall (total 4)
        selected = 1
        player_id = 3
        start_x = 0
        start_y = 30
        end_x = 0
        end_y = 105
        unk = $\x00c\x00 (total 4)
        building_id = 72
        flags = \x01\x01\x00\x00 (total 4)
        unit_ids = ListContainer: 
            33463
    end = 1110874
```

With the fix the result looks like this:

```
Container: 
    type = action (total 6)
    start = 1110834
    op = 1
    length = 28
    action = Container: 
        type_int = 105
        type = wall (total 4)
        selected = 1
        player_id = 3
        start_x = 30
        start_y = 105
        end_x = 36
        end_y = 99
        building_id = 72
        flags = \x01\x01\x00\x00 (total 4)
        unit_ids = ListContainer: 
            33463
    end = 1110874
```

I'm unsure if the unknown bytes are always `\x00`, this was the case in all my tests, but to prevent any errors i choose to use `Bytes(1)` instead of `Const('\x00')`.