### PR TITLE
Speed up "info" command (CLI)

### DIFF
--- a/mgz/cli.py
+++ b/mgz/cli.py
@@ -72,10 +72,9 @@ async def extract_rec(playback, path, select=None):
 def print_info(path):
     """Print basic info."""
     with open(path, 'rb') as handle:
-        header = mgz.header.parse_stream(handle)
-        handle.seek(0)
         summary = Summary(handle)
         dataset = summary.get_dataset()
+        header = summary.get_header()
         print('-------------')
         print(tabulate([
             ['Path', path],


### PR DESCRIPTION
The CLI's `info` command currently takes almost twice as long as necessary, because the header is parsed two times.

I aimed for a fix with minimal changes. If there's anything missing, please let me know.