### PR TITLE
support parsing of which item is being cancelled

### DIFF
--- a/mgz/body/actions.py
+++ b/mgz/body/actions.py
@@ -410,7 +410,8 @@ order = "order"/Struct(
     Padding(2),
     "building_id"/Int32sl, # -1 cancels production queue
     OrderTypeEnum("order_type"/Byte),
-    Padding(3),
+    "cancelOrder"/Int8ub, # when cancelling production queue, this indicates which item in the queue is to be cancelled
+    Padding(2),
     "x"/Float32l,
     "y"/Float32l,
     Padding(4), # const

--- a/mgz/body/actions.py
+++ b/mgz/body/actions.py
@@ -410,7 +410,7 @@ order = "order"/Struct(
     Padding(2),
     "building_id"/Int32sl, # -1 cancels production queue
     OrderTypeEnum("order_type"/Byte),
-    "cancelOrder"/Int8ub, # when cancelling production queue, this indicates which item in the queue is to be cancelled
+    "cancel_order"/Byte, # when cancelling production queue, this indicates which item in the queue is to be cancelled
     Padding(2),
     "x"/Float32l,
     "y"/Float32l,


### PR DESCRIPTION
the full parser did not support extracting which item is being cancelled when the action is an order to cancel production (building_id = -1). It seems this is a single byte that was being treated as padding. Not sure if this byte has a role when the order is not to cancel production, but since it was treated as padding prior to this pull request, this should not break anything.

Interestingly, the queue is grouped by unit/research type, excepting the current item in production. The current item in production is always 0. The next "group" (e.g. multiple vills) is 1, then the next group would be 2 (even if there are, for example, 10 vill queued ahead of that. As an example, if you have the queue:

villA -> villB-> villC -> loom

cancelling villA will have "cancelOrder" = 0.
cancelling villC will have "cancelOrder" = 1.
cancelling villB will have "cancelOrder" = 1.
cancelling loom will have "cancelOrder" = 2.
