### PR TITLE
Populate `rate_snapshot` attribute of each player with POSTGAME ope data

### DIFF
--- a/mgz/model/__init__.py
+++ b/mgz/model/__init__.py
@@ -267,6 +267,11 @@ def parse_match(handle):
                 enrich_action(action, action_data, dataset, consts)
                 actions.append(action)
                 inputs.add_action(action)
+            elif op_type is fast.Operation.POSTGAME:
+                # Write down the rating of each player after the game ended.
+                players_data: list = op_data["leaderboards"][0]["players"]
+                for player, player_data in zip(players.values(), players_data):
+                    player.rate_snapshot = player_data["rating"]
         except EOFError:
             break
 

--- a/mgz/model/compat.py
+++ b/mgz/model/compat.py
@@ -195,7 +195,7 @@ class ModelSummary:
                 position=(p.position.x, p.position.y),
                 mvp=None,
                 score=None,
-                rate_snapshot=None,
+                rate_snapshot=p.rate_snapshot,
                 cheater=None,
                 achievements=empty_achievements(),
                 prefer_random=p.prefer_random,


### PR DESCRIPTION
These changes populate the `rate_snapshot` attribute of each player so that they are accessible easily using the summary object.

They were tested with the code snippet below on a game from the most recent patch (78757).

    with open(path, "rb") as data:
        summary = mgz.summary.Summary(data)

    for player in summary.get_players():
        print(player["name"], player["rate_snapshot"])

