### PR TITLE
jump before object section in players parsing in fast header parser

### DIFF
--- a/mgz/fast/header.py
+++ b/mgz/fast/header.py
@@ -128,18 +128,22 @@ def parse_player(header, player_number, num_players, save):
         end += 10
     if data[end:end + 2] == BLOCK_END:
         end += 2
-    header.seek(offset + end)
 
     device = 0
     if save >= 37:
+        # sometimes the object parsing is a bit buggy and i can't figure out why, so we skip back before the object
+        # block and search from there for `player_end`.
+        header.seek(offset)
         offset = header.tell()
-        data = header.read(100)
+        data = header.read()
         # Jump to the end of player data
         player_end = re.search(b'\xff\xff\xff\xff\xff\xff\xff\xff.\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0b', data)
         if not player_end:
             raise RuntimeError("could not find player end")
         device = data[8]
         header.seek(offset + player_end.end())
+    else:
+        header.seek(offset + end)
 
     return dict(
         number=player_number,

--- a/tests/test_fast.py
+++ b/tests/test_fast.py
@@ -72,6 +72,21 @@ class TestFastDEScenarioWithTriggers(unittest.TestCase):
         self.assertEqual(len(players), 3)
 
 
+class TestFastDEObjectsBug(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        with open('tests/recs/de-50.6-objects-bug.aoe2record', 'rb') as handle:
+            cls.data = parse(handle)
+
+    def test_version(self):
+        self.assertEqual(self.data['version'], Version.DE)
+
+    def test_players(self):
+        players = self.data.get('players')
+        self.assertEqual(len(players), 9)
+
+
 class TestFastHD(unittest.TestCase):
 
     @classmethod


### PR DESCRIPTION
I have found several matches in which errors occurred during the "objects" parsing, and subsequently the parser was unable to find the player-end marker.
Unfortunately, I could not solve the actual problem, but maybe you have an idea. I have checked in a recorded game and added a unit test.
However, in order to make the parsing more reliable, I have added a workaround that jumps back to the position before the objects in every case and searches for the player-end marker from there, which works in all cases, but is of course more unperformant, as a lot of data has to be loaded into the RAM.