### PR TITLE
added save version 61.5 compatibility

### DIFF
--- a/mgz/fast/enums.py
+++ b/mgz/fast/enums.py
@@ -44,6 +44,7 @@ class Action(Enum):
     DE_UNKNOWN_40 = 40
     DE_TRANSFORM = 41
     RATHA_ABILITY = 43
+    DE_UNKNOWN_44 = 44
     AI_COMMAND = 53
     DE_UNKNOWN_80 = 80
     MAKE = 100
@@ -74,6 +75,7 @@ class Action(Enum):
     DE_UNKNOWN_135 = 135
     DE_UNKNOWN_136 = 136
     DE_UNKNOWN_138 = 138
+    DE_UNKNOWN_140 = 140
     DE_TRIBUTE = 196
     POSTGAME = 255
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,6 +1,7 @@
 import glob
 import unittest
-from mgz import header, body, fast
+from mgz import header, body, fast, Version
+from mgz.fast.header import parse
 
 
 def parse_file_full(path):
@@ -14,7 +15,7 @@ def parse_file_full(path):
             body.operation.parse_stream(f)
 
 
-def parse_file_fast(path):
+def parse_file_full_header_fast_body(path):
     with open(path, 'rb') as f:
         f.seek(0, 2)
         eof = f.tell()
@@ -25,17 +26,47 @@ def parse_file_fast(path):
             fast.operation(f)
 
 
+def parse_file_fast(path):
+    with open(path, 'rb') as f:
+        f.seek(0, 2)
+        eof = f.tell()
+        f.seek(0)
+
+        h = fast.header.parse(f)
+        fast.meta(f)
+        while f.tell() < eof:
+            fast.operation(f)
+
+        return h
+
+
 class TestFiles(unittest.TestCase):
 
     def test_files_full(self):
         parse_file_full('tests/recs/small.mgz')
         parse_file_full('tests/recs/de-13.07.aoe2record')
 
-    def test_files_fast(self):
+    def test_files_full_header_fast_body(self):
         # these files aren't supported by full header parser for now:
-        skip = {"tests/recs/de-50.6-scenario.aoe2record", "tests/recs/de-50.6-scenario-with-triggers.aoe2record"}
+        skip = {"tests/recs/de-50.6-scenario.aoe2record", "tests/recs/de-50.6-scenario-with-triggers.aoe2record",
+                "tests/recs/de-61.5.aoe2record", "tests/recs/de-61.5-2.aoe2record", "tests/recs/de-61.5-3.aoe2record"}
 
         for path in glob.glob('tests/recs/*'):
             if path in skip:
                 continue
-            parse_file_fast(path)
+
+            parse_file_full_header_fast_body(path)
+
+    def test_de_files_fast_header_fast_body(self):
+        for path in glob.glob('tests/recs/*'):
+            # test only DE records after save version 13
+            if not path.startswith("tests/recs/de") or \
+                    path.startswith("tests/recs/de-12") or \
+                    path.startswith("tests/recs/de-13"):
+                continue
+
+            h = parse_file_fast(path)
+
+            self.assertEqual(h["version"], Version.DE)
+            self.assertGreaterEqual(len(h["players"]), 1)
+            self.assertIn(h["map"]["dimension"], (120, 144, 168, 200, 220, 240, 480))


### PR DESCRIPTION
I've added Save-Version 61.5 compatibility for the fast header+body parser.

This patch is running since a few hours for us now, we could parse hundreds of games with it.

But i have to mention two things which i'm not happy with for now:

**Finding Marker at scenario parsing**
Although this works i couldn't find a way to do it without this marker (as it was before). I think there might be better ways to do it.

**Unit tests**
The different parser implementations support different versions, the fast header parser doesn't seem to support DE save-versions <=13 (at least it didn't at my tests, and i couldn't find the conditional parsings for versions like 13.17 as in the full parser, for example).
And since i've now added unit tests for the fast header parser i had to add some ugly guard checks to skip some savegames in some conditions.
Maybe it would be better to group the savegames in different folders or smth. like that.

If you already work on your own implementation just skip this pr and we will fetch your upstream changes as soon as they are available.