### PR TITLE
Add "build/" to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/
+build/
 mgz.egg-info/
 venv/
 .tox/


### PR DESCRIPTION
If you install the repo using "pip install ." in the repo, which is preferred nowadays over interacting with setup.py directly, pip builds the library in "build/".