### PR TITLE
fix: Add support for savegames version 64.3

### DIFF
--- a/mgz/fast/header.py
+++ b/mgz/fast/header.py
@@ -9,7 +9,7 @@ import zlib
 from mgz.util import get_version, unpack, Version, as_hex
 
 ZLIB_WBITS = -15
-CLASSES = [b'\x0a', b'\x1e', b'\x46', b'\x50']
+CLASSES = [b'\x0a', b'\x1e', b'\x46', b'\x50', b'\x14']
 BLOCK_END = b'\x00\x0b'
 REGEXES = {}
 SKIP_OBJECTS = [

--- a/mgz/fast/header.py
+++ b/mgz/fast/header.py
@@ -74,7 +74,7 @@ def object_block(data, pos, player_number, index):
     offset = None
     while True:
         if not offset:
-            match = REGEXES[player_number].search(data, pos)
+            match = REGEXES[player_number].search(data, pos, pos + 10000)
             end = data.find(BLOCK_END, pos) - pos + len(BLOCK_END)
             if match is None:
                 break
@@ -115,7 +115,8 @@ def parse_player(header, player_number, num_players, save):
         rep = num_players
     type_, *diplomacy, name_length = unpack(f'<bx{num_players}x{rep}i5xh', header)
     name, resources = unpack(f'<{name_length - 1}s2xIx', header)
-    header.read(resources * 4)
+    resources_len = 8 if save >= 63 else 4
+    header.read(resources * resources_len)
     start_x, start_y, civilization_id, color_id = unpack('<xff9xb3xbx', header)
     offset = header.tell()
     data = header.read()

--- a/mgz/fast/header.py
+++ b/mgz/fast/header.py
@@ -277,9 +277,11 @@ def parse_scenario(data, num_players, version, save):
     map_id, difficulty_id = unpack('<II', data)
     remainder = data.read()
     if version is Version.DE:
-        if save >= 63:
+        if save >= 64.3:
+            settings_version = 4.1
+        elif save >= 63:
             settings_version = 3.9
-        if save >= 61.5:
+        elif save >= 61.5:
             settings_version = 3.6
         elif save >= 37:
             settings_version = 3.5
@@ -427,6 +429,8 @@ def parse_de(data, version, save, skip=False):
         data.read(1)
         if save >= 25.06:
             data.read(8)
+        if save >= 64.3:
+            data.read(4)
 
         players.append(dict(
             number=number,
@@ -451,6 +455,8 @@ def parse_de(data, version, save, skip=False):
             de_string(data)
             de_string(data)
             data.read(38)
+            if save >= 64.3:
+                data.read(4)
     data.read(4)
     rated = unpack('b', data)
     allow_specs = unpack('b', data)

--- a/mgz/fast/header.py
+++ b/mgz/fast/header.py
@@ -173,6 +173,8 @@ def parse_lobby(data, version, save):
             data.read(5)
         if save >= 37:
             data.read(8)
+        if save >= 64.3:
+            data.read(16)
     data.read(8)
     if version not in (Version.DE, Version.HD):
         data.read(1)

--- a/mgz/header/de.py
+++ b/mgz/header/de.py
@@ -43,6 +43,7 @@ player = Struct(
     "prefer_random"/Flag,
     "custom_ai"/Flag,
     If(lambda ctx: find_save_version(ctx) >= 25.06, "handicap"/Bytes(8)),
+    If(lambda ctx: find_save_version(ctx) >= 64.3, "unknown_de_64_3" / Int32ul),
 )
 
 string_block = Struct(
@@ -123,6 +124,7 @@ de = "de"/Struct(
         "i1"/Int32ul,
         "i2"/Int32ul,
         "a4"/Bytes(8),
+        If(lambda ctx: find_save_version(ctx) >= 64.3, "unknown_de_64_3" / Int32ul),
     ))),
     separator,
     "ranked"/Flag,

--- a/mgz/header/lobby.py
+++ b/mgz/header/lobby.py
@@ -14,6 +14,7 @@ lobby = "lobby"/Struct(
     If(lambda ctx: find_save_version(ctx) >= 20.06, Padding(9)),
     If(lambda ctx: find_save_version(ctx) >= 26.16, Bytes(5)),
     If(lambda ctx: find_save_version(ctx) >= 37, Bytes(8)),
+    If(lambda ctx: find_save_version(ctx) >= 64.3, Bytes(16)),
     Array(8, "teams"/Byte), # team number selected by each player
     If(lambda ctx: ctx._.version not in (Version.DE, Version.HD),
         Padding(1),

--- a/mgz/header/objects.py
+++ b/mgz/header/objects.py
@@ -110,6 +110,7 @@ static = "static"/Struct(
         If(lambda ctx: find_save_version(ctx) >= 20.16, Struct(
             "peek"/Peek(Bytes(6)),
             If(lambda ctx: find_save_version(ctx) >= 25.22 and (find_type(ctx) == 10 or find_save_version(ctx) >= 63.0), Bytes(1)),
+            If(lambda ctx: find_save_version(ctx) >= 64.3, Bytes(1)),
             If(lambda ctx: find_save_version(ctx) < 25.22 and find_type(ctx) == 10 and ctx.peek[0] == 0 and ctx.peek[0:2] != b"\x00\x0b", Bytes(1)),
             If(lambda ctx: find_type(ctx) == 20 and ctx.peek[4] == 0 and ctx.peek[4:6] != b"\x00\x0b", Bytes(1)),
         )),
@@ -402,6 +403,7 @@ combat = "combat"/Struct(
     "de_2"/If(lambda ctx: find_save_version(ctx) >= 26.16, Bytes(16)),
     "de_3"/If(lambda ctx: 63 > find_save_version(ctx) >= 26.18, Bytes(1)),
     "de_4"/If(lambda ctx: find_save_version(ctx) >= 61.5, Bytes(4)),
+    "de_5"/If(lambda ctx: find_save_version(ctx) >= 64.3, Bytes(19)),
     "next_volley"/Byte,
     "using_special_animation"/Byte,
     "own_base"/Byte,
@@ -447,6 +449,7 @@ combat = "combat"/Struct(
             )
         )
     ),
+    "de_unknown_64_3_1"/If(lambda ctx: find_save_version(ctx) >= 64.3, Byte),
 )
 
 production_queue = "production_queue"/Struct(
@@ -493,6 +496,7 @@ building = "building"/Struct(
     "de_unk_4"/If(lambda ctx: find_save_version(ctx) >= 26.16, Bytes(4)),
     "de_unk_5"/If(lambda ctx: find_save_version(ctx) >= 50.4, Bytes(4)),
     "de_unk_6"/If(lambda ctx: find_save_version(ctx) >= 61.5, Bytes(12)),
+    "de_unk_7"/If(lambda ctx: find_save_version(ctx) >= 64.3, Bytes(4)),
 )
 
 

--- a/mgz/header/scenario.py
+++ b/mgz/header/scenario.py
@@ -151,9 +151,10 @@ game_settings = "game_settings"/Struct(
             If(lambda ctx: 37 > find_save_version(ctx) >= 26.21, Find(struct.pack('<d', 3.2), None)),
             If(lambda ctx: 61.5 > find_save_version(ctx) >= 37, Find(struct.pack('<d', 3.5), None)),
             If(lambda ctx: 63 > find_save_version(ctx) >= 61.5, Find(struct.pack('<d', 3.6), None)),
-            If(lambda ctx: find_save_version(ctx) >= 63, Find(struct.pack('<d', 3.9), None)),
+            If(lambda ctx: 64.3 > find_save_version(ctx) >= 63, Find(struct.pack('<d', 3.9), None)),
+            If(lambda ctx: find_save_version(ctx) >= 64.3, Find(struct.pack('<d', 4.1), None)),
         ),
-        "end_of_game_settings"/Find(b'\x9a\x99\x99\x99\x99\x99\xf9\\x3f', None)
+        "end_of_game_settings"/Find(b'\x9a\x99\x99\x99\x99\x99\xf9\\x3f', None),
     )
 )
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,6 +1,7 @@
 import glob
 import unittest
 from mgz import header, body, fast
+from mgz.summary import ModelSummary, FullSummary
 
 
 def parse_file_full(path):
@@ -24,6 +25,10 @@ def parse_file_fast(path):
         while f.tell() < eof:
             fast.operation(f)
 
+def parse_file_summary(path, summary_class):
+    with open(path, 'rb') as f:
+        summary_class(f)
+
 
 class TestFiles(unittest.TestCase):
 
@@ -39,3 +44,11 @@ class TestFiles(unittest.TestCase):
             if path in skip:
                 continue
             parse_file_fast(path)
+
+    @unittest.skip("This test is meant to be run manually when debugging issues in a specific rec")
+    def test_single_rec(self):
+        rec = "tests/recs/de-64.3.aoe2record"
+        parse_file_fast(rec)
+        parse_file_summary(rec, FullSummary)
+        parse_file_summary(rec, ModelSummary)
+


### PR DESCRIPTION
This fixes the parsing of savegames generated with the latest patch. It only fixes the `FullSummary`, the `ModelSummary` still has issues when parsing some new objects. I wasn't able to figure out a solution there yet, but in the meantime this should at least provide some parsing capability.

I added a skipped test that I find useful when developing to test my changes against a specific rec. I think it can be generally useful, hence I decided to include it in the commit.