### PR TITLE
parse uptimes from chat and return in model

### DIFF
--- a/mgz/common/chat.py
+++ b/mgz/common/chat.py
@@ -3,7 +3,66 @@ import json
 import logging
 from enum import Enum
 
+from mgz.fast import Age
+
 LOGGER = logging.getLogger(__name__)
+FEUDAL_AGE_MARKERS = [
+    '봉건 시대',
+    'Edad Feudal',
+    '封建时代',
+    'Feudalzeit',
+    'Feodal Çağ',
+    '封建時代',
+    'Edad Feudal',
+    '領主の時代',
+    'Zaman Feudal',
+    'Età feudale',
+    'Feudal Age',
+    'Thời phong kiến',
+    'सामंतवादी युग',
+    'Era Feudalna',
+    'Idade Feudal',
+    'Âge féodal',
+    'Феодальная эпоха',
+]
+CASTLE_AGE_MARKERS = [
+    '성주 시대',
+    'Ed. Castillos',
+    '城堡时代',
+    'Ritterzeit',
+    'Kale Çağı',
+    '城堡時代',
+    'Edad de los Castillos',
+    '城主の時代',
+    'Zaman Kastil',
+    'Età dei castelli',
+    'Castle Age',
+    'Thời lâu đài',
+    'परिवर्तन युग',
+    'Era Zamków',
+    'Idade dos Castelos',
+    'Âge des châteaux',
+    'Замковая эпоха',
+]
+IMPERIAL_AGE_MARKERS = [
+    '왕정 시대',
+    'Edad Imperial',
+    '帝王时代',
+    'Imperialzeit',
+    'İmparatorluk Çağı',
+    '帝王時代',
+    'Edad Imperial',
+    '帝王の時代',
+    'Zaman Empayar',
+    'Età imperiale',
+    'Imperial Age',
+    'Thời đế quốc',
+    'साम्राज्यवादी युग',
+    'Era Imperiów',
+    'Idade Imperial',
+    'Âge impérial',
+    'Имперская эпоха',
+]
 AGE_MARKERS = [
     'advanced to the',
     'a progressé vers',
@@ -26,6 +85,9 @@ AGE_MARKERS = [
     'ha raggiunto',
     'avanzó a Ed',
     'đã nâng cấp',
+    'युग में उन्नत है।',   # hi
+    'telah mara ke', # ms
+    'geçti',         # tr
 ]
 SAVE_MARKERS = [
     'Continuar con la partida en vez de guardar y salir',
@@ -84,10 +146,6 @@ def parse_chat(line, encoding, timestamp, players, diplomacy_type=None, originat
         if line.find(save_marker) > 0:
             data['type'] = Chat.SAVE
             return data
-    for age_marker in AGE_MARKERS:
-        if line.find(age_marker) > 0:
-            data['type'] = Chat.AGE
-            return data
     if line.find('Voobly: Ratings provided') > 0:
         _parse_ladder(data, line)
     elif line.find('Voobly') == 3:
@@ -102,6 +160,17 @@ def parse_chat(line, encoding, timestamp, players, diplomacy_type=None, originat
         _parse_json(data, line, diplomacy_type)
     else:
         _parse_chat(data, line, players, diplomacy_type)
+
+    for age_marker in AGE_MARKERS:
+        if line.find(age_marker) > 0:
+            data['type'] = Chat.AGE
+            if any(marker in line for marker in FEUDAL_AGE_MARKERS):
+                data['age'] = Age.FEUDAL_AGE
+            if any(marker in line for marker in CASTLE_AGE_MARKERS):
+                data['age'] = Age.CASTLE_AGE
+            if any(marker in line for marker in IMPERIAL_AGE_MARKERS):
+                data['age'] = Age.IMPERIAL_AGE
+
     if not _validate(data, players):
         data['type'] = Chat.DISCARD
     return data

--- a/mgz/fast/__init__.py
+++ b/mgz/fast/__init__.py
@@ -2,7 +2,7 @@
 import io
 import struct
 
-from mgz.fast.enums import Operation, Action, Postgame
+from mgz.fast.enums import Operation, Action, Postgame, Age
 from mgz.fast.actions import parse_action_71094
 from mgz.util import check_flags, unpack
 

--- a/mgz/fast/enums.py
+++ b/mgz/fast/enums.py
@@ -87,3 +87,10 @@ class Postgame(Enum):
     """Postgame types."""
     WORLD_TIME = 1
     LEADERBOARDS = 2
+
+class Age(Enum):
+    """Age types."""
+    DARK_AGE = 1
+    FEUDAL_AGE = 2
+    CASTLE_AGE = 3
+    IMPERIAL_AGE = 4

--- a/mgz/model/__init__.py
+++ b/mgz/model/__init__.py
@@ -233,6 +233,7 @@ def parse_match(handle):
     resigned = []
     actions = []
     viewlocks = []
+    uptimes = []
     eapm = collections.Counter()
     last_viewlock = None
     while True:
@@ -257,6 +258,14 @@ def parse_match(handle):
                         players[chat['player_number']]
                     ))
                     inputs.add_chat(chats[-1])
+                if chat['type'] == ChatEnum.AGE:
+                    uptimes.append(
+                        Uptime(
+                            timedelta(milliseconds=chat['timestamp'] + data['map']['restore_time']),
+                            chat['age'],
+                            players.get(chat['player_number']),
+                        )
+                    )
             elif op_type is fast.Operation.ACTION:
                 action_type, action_data = op_data
                 action = Action(timedelta(milliseconds=timestamp), action_type, action_data)
@@ -363,7 +372,8 @@ def parse_match(handle):
         data['de']['visibility_id'] == 2 if data['version'] is Version.DE else None,
         get_hash(data),
         actions,
-        inputs.inputs
+        inputs.inputs,
+        uptimes
     )
 
 

--- a/mgz/model/definitions.py
+++ b/mgz/model/definitions.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from datetime import timedelta, datetime
 from mgz.fast import Action as ActionEnum
+from mgz.fast import Age as AgeEnum
 from mgz.util import Version
 
 
@@ -141,6 +142,17 @@ class Chat:
     def __repr__(self):
         return f'[{self.timestamp}] {self.player}: {self.message}'
 
+@dataclass
+class Uptime:
+    """Represents an advanced to age event."""
+
+    timestamp: timedelta
+    age: AgeEnum
+    player: Player
+
+    def __repr__(self):
+        return f'[{self.timestamp}] {self.player} -> {self.age}'
+
 
 @dataclass
 class Match:
@@ -192,3 +204,4 @@ class Match:
     hash: str
     actions: list
     inputs: list
+    uptimes: list


### PR DESCRIPTION
Hi
I noticed that you can find out the uptimes of the players using the chat messages. but in the parsed model I use there are only chat messages between players included. so I cannot find out the uptimes from that in my project.

Can we include parsing of the uptimes in this project?

Output is:

```
[
    {
        "timestamp": "0:08:15.481000",
        "age": "FEUDAL_AGE",
        "player": 4
    },
    {
        "timestamp": "0:09:18.258000",
        "age": "FEUDAL_AGE",
        "player": 3
    },
    {
        "timestamp": "0:10:19.925000",
        "age": "FEUDAL_AGE",
        "player": 2
    },
    {
        "timestamp": "0:10:57.127000",
        "age": "FEUDAL_AGE",
        "player": 6
    },
    {
        "timestamp": "0:11:44.615000",
        "age": "FEUDAL_AGE",
        "player": 1
    },
    {
        "timestamp": "0:12:10.907000",
        "age": "FEUDAL_AGE",
        "player": 5
    },
    {
        "timestamp": "0:14:50.599000",
        "age": "CASTLE_AGE",
        "player": 2
    },
    ...
]
```

I also added three missing age markers from the translation files:
<img width="739" height="431" alt="image" src="https://github.com/user-attachments/assets/ed696ec0-b3a2-48b9-b4e1-b412e636e7d3" />
