### PR TITLE
Rename name2 to censored_name

### DIFF
--- a/mgz/fast/header.py
+++ b/mgz/fast/header.py
@@ -427,9 +427,9 @@ def parse_de(data, version, save, skip=False):
         de_string(data)
         data.read(1)
         ai_name = de_string(data)
-        name = de_string(data)
         if save >= 66.3:
-            _name2 = de_string(data)
+            censored_name = de_string(data)
+        name = de_string(data)
         type = unpack('<I', data)
         profile_id, number = unpack('<I4xi', data)
         if save < 25.22:
@@ -447,6 +447,7 @@ def parse_de(data, version, save, skip=False):
             team_id=team_id,
             ai_name=ai_name,
             name=name,
+            censored_name=censored_name,
             type=type,
             profile_id=profile_id,
             civilization_id=civilization_id,

--- a/mgz/fast/header.py
+++ b/mgz/fast/header.py
@@ -447,7 +447,7 @@ def parse_de(data, version, save, skip=False):
             team_id=team_id,
             ai_name=ai_name,
             name=name,
-            censored_name=censored_name,
+            censored_name=censored_name if save >= 66.3 else name,
             type=type,
             profile_id=profile_id,
             civilization_id=civilization_id,

--- a/mgz/header/de.py
+++ b/mgz/header/de.py
@@ -33,8 +33,8 @@ player = Struct(
     "ai_type"/de_string,
     "ai_civ_name_index"/Byte,
     "ai_name"/de_string,
+    "censored_name"/If(lambda ctx: find_save_version(ctx) >= 66.3,de_string),
     "name"/de_string,
-    "name2"/If(lambda ctx: find_save_version(ctx) >= 66.3,de_string),
     "type"/PlayerTypeEnum(Int32ul),
     "profile_id"/Int32sl, # -1 if it's an empty slot
     "ai_unknown" / Int32sl, # Often 0, sometimes -1 for AI players

--- a/mgz/header/objects.py
+++ b/mgz/header/objects.py
@@ -205,7 +205,7 @@ moving = "moving"/Struct(
     "de_moving"/If(lambda ctx: find_version(ctx) == Version.DE, Bytes(17)),
     "ver2616"/If(lambda ctx: 37 > find_save_version(ctx) >= 26.16, Bytes(8)),
     "ver37"/If(lambda ctx: 63 > find_save_version(ctx) >= 37, Bytes(5)),
-    "ver63"/If(lambda ctx: find_save_version(ctx) >= 63, Bytes(4)),
+    "ver63"/If(lambda ctx: find_save_version(ctx) >= 63, Bytes(4))
 )
 
 move_to = "move_to"/Struct(


### PR DESCRIPTION
The new name field that was added with rec version 66.3 is the censored version of the name: in case the name contains something that aoe2 considers "bad" it will consist of `###` instead of the actual name.

After brief discussion, the most sensible thing to do is to keep the name as the uncensored version. I added the censored version as well in case someone has a use or desire for it.