### PR TITLE
fix: bug with uptimes being parsed from some replays

### DIFF
--- a/mgz/common/chat.py
+++ b/mgz/common/chat.py
@@ -295,6 +295,10 @@ def _parse_chat(data, line, players, diplomacy_type):
     for player_h in players:
         if player_h['name'] in player:
             number = player_h['number']
+
+    if not number and line.startswith('@#'):
+        number = int(line[2])
+    
     data.update({
         'type': Chat.MESSAGE,
         'player_number': number,


### PR DESCRIPTION
Occasionally, when parsing replays, the uptime chat will be in a different format (string messages instead of json). Oddly enough, this even happens with the same gameId from different POVs. An example:

string uptime: https://aoe.ms/replay/?gameId=446266813&profileId=12981532 (`@#5<player_id,5,0> advanced to the Castle Age.`)
JSON uptime: https://aoe.ms/replay/?gameId=446266813&profileId=18944375 (`{"player":5,"channel":0,"message":"<player_id,5,0> advanced to the Castle Age.","tauntNumber":-1,"messageAGP":"@#5<player_id,5,0> advanced to the Castle Age."}`)

Currently, the parser is only setup to parse the player number for JSON uptime messages. Because of that, the string uptime messages get filtered out and are not returned by the parser.

To support string uptimes, I'm simply checking detecting the player number as the character after `@#` if those characters are at the start of the line.

I tested various replay files, and didn't have an impact on other chat features from what I could tell.