### PR TITLE
feat: expose per-player handicap percentage from replay headers

### DIFF
--- a/mgz/fast/header.py
+++ b/mgz/fast/header.py
@@ -464,8 +464,10 @@ def parse_de(data, version, save, skip=False):
             data.read(8)
         prefer_random = unpack('b', data)
         data.read(1)
+        handicap = 100
         if save >= 25.06:
-            data.read(8)
+            handicap_data = data.read(8)
+            handicap = struct.unpack_from('<I', handicap_data, 4)[0]
         if save >= 64.3:
             data.read(4)
 
@@ -480,7 +482,8 @@ def parse_de(data, version, save, skip=False):
             profile_id=profile_id,
             civilization_id=civilization_id,
             custom_civ_selection=custom_civ_selection,
-            prefer_random=prefer_random == 1
+            prefer_random=prefer_random == 1,
+            handicap=handicap
         ))
     data.read(12)
     if 66.3 > save >= 37:

--- a/mgz/model/__init__.py
+++ b/mgz/model/__init__.py
@@ -188,6 +188,7 @@ def parse_match(handle):
             player.get('profile_id'),
             [],
             player.get('prefer_random'),
+            player.get('handicap', 100),
         )
 
     # Assign teams

--- a/mgz/model/definitions.py
+++ b/mgz/model/definitions.py
@@ -54,6 +54,7 @@ class Player:
     profile_id: int
     timeseries: list[TimeseriesRow]
     prefer_random: bool = None
+    handicap: int = 100
     team: list = None
     team_id: int = None
     winner: bool = False


### PR DESCRIPTION
The 8 handicap bytes per player (save version >= 25.06) in `parse_de()` were being read and discarded via `data.read(8)`. This PR unpacks the handicap percentage from those bytes and exposes it as `player.handicap` on the Player model.

## Changes

- **`mgz/fast/header.py`**: Decode the second int32 from the 8-byte handicap block as the handicap value (100–200%)
- **`mgz/model/definitions.py`**: Add `handicap: int = 100` field to the `Player` dataclass
- **`mgz/model/__init__.py`**: Pass `player.get('handicap', 100)` through to the Player constructor

## Details

- Default value is `100` (no handicap), matching AoE2 DE's default
- No breaking changes — the field is optional with a default value
- Handicap is a standard AoE2 DE game setting (100–200% in 5% increments, boosts economy and production speed)
- Useful for LAN party stat tracking, replay analysis tools, and balancing insights